### PR TITLE
setup.py: Automaticall install mdxml.conf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 __author__ = 'GHajba'
+from distutils.command.install import INSTALL_SCHEMES
 from distutils.core import setup
+
+# Credits: http://stackoverflow.com/a/3042436/5091738
+for scheme in INSTALL_SCHEMES.values():
+    scheme['data'] = scheme['purelib']
 
 setup(
     name='wpedit',
@@ -14,4 +19,5 @@ setup(
     classifiers=['Programming Language :: Python',
                  'License :: OSI Approved :: MIT License', ],
     requires=[('Markdown'), ("python.wordpress.xmlrpc")],
+    data_files=[('wpedit', ['wpedit/mdxml.conf'])],
 )


### PR DESCRIPTION
Previously mdxml.conf wasn't installed along with the rest of the
package, because conf files are not automatically included by distutils.
Fix this in a slightly hacky way.

I recommend switching from distutils to setuptools, because you can
include files less hackily and you can tell pip which dependencies to
download. Right now users might stumble over exceptions indicating that
the modules markdown or wordpress_xmlrpc are not found.
